### PR TITLE
Encode class in varnish path correctly

### DIFF
--- a/KwfVarnish/Events.php
+++ b/KwfVarnish/Events.php
@@ -67,7 +67,7 @@ class KwfVarnish_Events extends Kwf_Events_Subscriber
     {
         $varnishDomain = $ev->component->getBaseProperty('varnish.domain');
         if ($varnishDomain) {
-            $url = 'http://'.$varnishDomain.'/media/'.$ev->class.'/'.$ev->component->componentId.'/*';
+            $url = 'http://'.$varnishDomain.'/media/'.rawurlencode($ev->class).'/'.$ev->component->componentId.'/*';
             KwfVarnish_Purge::purge($url);
         }
     }


### PR DESCRIPTION
Component-Class can contain ">" when using childSettings
See https://github.com/koala-framework/koala-framework/blob/5.2/Kwf/Media.php#L32